### PR TITLE
Update monit cookbook for new binary

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -100,7 +100,7 @@ default["monit"]["source"]["compiler_optimized"] = true
 default["monit"]["binary_install"] = false
 default["monit"]["binary_uninstall"] = false
 
-default["monit"]["binary"]["version"] = "5.11"
+default["monit"]["binary"]["version"] = "5.12.2"
 default["monit"]["binary"]["prefix"] = "/usr"
-default["monit"]["binary"]["url"] = "http://mmonit.com/monit/dist/binary/5.11/monit-5.11-linux-x64.tar.gz"
-default["monit"]["binary"]["checksum"] = "bee00da32dbf4c948587277ac66bac9c68373aff6a15924b632cf9508e097783"
+default["monit"]["binary"]["url"] = "http://mmonit.com/monit/dist/binary/#{node['monit']['binary']['version']}/monit-#{node['monit']['binary']['version']}-linux-x64.tar.gz"
+default["monit"]["binary"]["checksum"] = "4908143752d0ee5081a50389a9206b7c905f9f8922a062a208fecf6e729a3c77"

--- a/metadata.rb
+++ b/metadata.rb
@@ -1,10 +1,10 @@
 name              "monit"
-maintainer        "Phil Cohen"
-maintainer_email  "github@phlippers.net"
+maintainer        "Rick Hull"
+maintainer_email  "rick.hull@glassdoor.com"
 license           "MIT"
 description       "Configures monit"
 long_description  "Please refer to README.md"
-version           "1.5.7"
+version           "1.5.8"
 
 recipe "monit", "Sets up the service definition and default checks."
 recipe "monit::install_source", "Compiles and installs monit from source."


### PR DESCRIPTION
- old binary was removed and is unavailable
- take over maintainership
- update cookbook version to 1.5.8
- make the download url refer the binary version specified
  next update: only the version needs to change, along with checksum
